### PR TITLE
bug: switch tool to use python 3.11 for better compatibility

### DIFF
--- a/tool.gpt
+++ b/tool.gpt
@@ -9,4 +9,4 @@ args: prompt: The query prompt to ask the vector database. URL Encoded string.
 name: server
 description: The knowledge server
 
-#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/src/main.py
+#!sys.daemon /usr/bin/env python3.11 ${GPTSCRIPT_TOOL_DIR}/src/main.py


### PR DESCRIPTION
duckdb for python 3.12 didn't seem to be available as precompile for linux. I dont' know about other platforms. But 3.11 worked fine.